### PR TITLE
#83 Bugfix: added interception of non-text messages for captcha

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,6 +40,13 @@ good = ["хороший", "отличный", "лучший"]
 "attempts" = 5
 "bar_length" = 20
 
+[captcha_properties]
+content_types = [
+    "animation", "audio", "contact", "dice", 
+    "document", "location", "photo", "text", 
+    "sticker", "video", "video_note", "voice"
+]
+
 [sticker_to_sticker]
 "терпи" = ["терплю"]
 "терплю" = "терпи"

--- a/src/captcha_manager.py
+++ b/src/captcha_manager.py
@@ -206,12 +206,12 @@ def handle_verify_captcha(message):
         )
         return
 
-    user_input = message.text.strip().lower()
+    bot.delete_message(message.chat.id, message.message_id)
+
+    user_input = (message.text or "").strip().lower() or None
     if user_input == user["answer"].lower():
-        bot.delete_message(message.chat.id, message.message_id)
         pass_user(user_id, user_input)
     else:
-        bot.delete_message(message.chat.id, message.message_id)
         on_failed_attempt(user_id, user_input)
 
 

--- a/src/commands/dispatcher.py
+++ b/src/commands/dispatcher.py
@@ -20,6 +20,7 @@ from commands.text import handle_long, handle_text_to_sticker, handle_text_to_te
 from config import (
     MESSAGE_MAX_LEN,
     allowed_chats,
+    captcha_content_types,
     check_mods,
     drinks,
     espers,
@@ -50,7 +51,7 @@ unknown_cmd = (
 chat_ok = lambda p: lambda m: p(m) and in_allowed_chat(m)
 message_ok = lambda t: lambda m: head(choice_one_match(m.text, t.keys()))
 sticker_ok = lambda t: lambda m: m.sticker.file_id in t.keys()
-cmd_ok = lambda m: is_cmd_for_bot(split_cmd(m))
+cmd_ok = lambda m: is_cmd_for_bot(split_cmd(m)) and not is_captcha_user(m)
 cmd_no_ok = lambda m: unknown_cmd(split_cmd(m))
 is_captcha_user = lambda m: m.from_user.id in CAPTCHA_USERS
 
@@ -106,6 +107,15 @@ handlers = check_mods(
             handle_cmd: handler(cmd_ok, commands=list(COMMANDS.keys())),
             handle_unknown: handler(cmd_no_ok),
         },
+        "captcha": {
+            handle_new_user: handler(
+                lambda m: bool(getattr(m, "new_chat_members", None)),
+                content_types=["new_chat_members"],
+            ),
+            handle_verify_captcha: handler(
+                is_captcha_user, content_types=captcha_content_types
+            ),
+        },
         "long_message": {handle_long(long_message): handler(is_long_message)},
         "reply": {
             handle_text_to_sticker(text_to_sticker): handler(
@@ -116,17 +126,14 @@ handlers = check_mods(
                 sticker_ok(sticker_to_sticker), content_types=["sticker"]
             ),
         },
-        "captcha": {
-            handle_new_user: handler(
-                lambda m: bool(getattr(m, "new_chat_members", None)),
-                content_types=["new_chat_members"],
-            ),
-            handle_verify_captcha: handler(is_captcha_user),
-        },
     }
 )
 
-inline_handlers = {handle_inline_help(COMMANDS): {lambda query: query.query == ""}}
+inline_handlers = {
+    handle_inline_help(COMMANDS): {
+        lambda query: query.query == "" and not is_captcha_user(query)
+    }
+}
 
 query_check_data = lambda d: lambda c: chat_ok(c.message) and c.data.startswith(d)
 query_handlers = check_mods(

--- a/src/config.py
+++ b/src/config.py
@@ -28,7 +28,10 @@ config = toml.load("config.toml")
 captcha_properties = {
     "gen": config["captcha_properties"]["gen"],
     "validate": config["captcha_properties"]["validate"],
+    # types of content that the captcha will intercept as a check on the user's answer
+    "content_types": config["captcha_properties"].get("content_types", ["text"]),
 }
+captcha_content_types = captcha_properties["content_types"]
 
 greeting_message = (
     config.get("welcome_message_for_new_members")


### PR DESCRIPTION
Messages of any type will be intercepted by the captcha until the user passes it and will not call other handlers.