### PR TITLE
Fixes of the Categories module

### DIFF
--- a/src/commands/dispatcher.py
+++ b/src/commands/dispatcher.py
@@ -15,7 +15,12 @@ from commands.anime import handle_anime
 from commands.drink_or_not import handle_drink_or_not
 from commands.help import handle_help, handle_inline_help, handle_unknown
 from commands.like import handle_like, handle_top_likes
-from commands.play_event import handle_play, handle_top_winners, handle_winner
+from commands.play_event import (
+    handle_play,
+    handle_players,
+    handle_top_winners,
+    handle_winner,
+)
 from commands.roll_custom_title import (
     handle_title_change_attempt,
     prepare_game,
@@ -91,6 +96,7 @@ COMMANDS = {
     },
     "play": {
         "play": (handle_play, "Узнать своё значение в сегодняшней категории"),
+        "players": (handle_players, "Показать всех игроков"),
         "winner": (handle_winner, "Показать победителя дня"),
         "top_winners": (handle_top_winners, "Топ победителей за всё время"),
     },

--- a/src/commands/play_event.py
+++ b/src/commands/play_event.py
@@ -278,3 +278,23 @@ def handle_top_winners(message):
         message.chat.id,
         "🏆 Топ победителей за всё время:",
     )(message)
+
+
+def handle_players(message):
+    """Show all eligible players"""
+    chat_id = message.chat.id
+    players = get_players(chat_id)
+
+    if len(players) == 0:
+        bot.reply_to("❌ В чате нет подходящих участников (нужны админы)")(message)
+        return
+
+    header = f"👥 Список игроков [{len(players)}]:"
+    header = bot.escape_markdown_v2(f"👥 Список игроков [{len(players)}]:")
+
+    players_list = "\n".join(
+        f"{bot.escape_markdown_v2(f'{position + 1}.')} {bot.to_link_user_v2(player)}"
+        for position, player in enumerate(players)
+    )
+
+    bot.reply_with_user_links(f"{header}\n{players_list}", mode="MarkdownV2")(message)

--- a/src/commands/play_event.py
+++ b/src/commands/play_event.py
@@ -14,7 +14,7 @@ from .play.play import PlayableCategory
 from .play.play_utils import get_current_playable_category
 
 # Event ID for play categories
-PLAY_EVENT_ID = 1
+PLAY_EVENT_ID = 0
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Two issues are fixed:
1. `/winners` command now shows proper (up-to-date) win counts for users.
2. `/players` command is returned.

Unresolved issues: 
- [ ] Add an option to see the winner for the `/play` response.